### PR TITLE
Patch 2

### DIFF
--- a/PipedriveNet/Dto/OrganizationDto.cs
+++ b/PipedriveNet/Dto/OrganizationDto.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PipedriveNet.Dto
+{
+    public class OrganizationDto
+    {
+        public int OrgId { get; set; }
+        public string Name { get; set; }
+        public int PeopleCount { get; set; }
+        public string CCEmail { get; set; }
+
+        public int Value { set { OrgId = value; } }
+    }
+}

--- a/PipedriveNet/Dto/PersonDto.cs
+++ b/PipedriveNet/Dto/PersonDto.cs
@@ -5,7 +5,7 @@ namespace PipedriveNet.Dto
 	public class PersonDto
 	{
         public int Id { get; set; }
-        public int? OrgId { get; set; }
+        public OrganizationDto OrgId { get; set; }
         public string Name { get; set; }
         public string FistName { get; set; }
         public string LastName { get; set; }


### PR DESCRIPTION
Update to fix an issue when retrieving list of Person's from pipedrive. If a person is associated with an organization, then an object representing the organization is returned, not the Id of the org.